### PR TITLE
Fix memory alignment problem on ARM6

### DIFF
--- a/scclient/client.go
+++ b/scclient/client.go
@@ -12,9 +12,9 @@ import (
 )
 
 type Client struct {
+	counter             utils.AtomicCounter
 	authToken           *string
 	url                 string
-	counter             utils.AtomicCounter
 	socket              gowebsocket.Socket
 	onConnect           func(client Client)
 	onConnectError      func(client Client, err error)
@@ -27,7 +27,6 @@ type Client struct {
 }
 
 func New(url string) Client {
-
 	return Client{
 		url:      url,
 		counter:  utils.AtomicCounter{Counter: 0},


### PR DESCRIPTION
The Client struct is not working on ARM-based systems because of a wrong memory alignment. This fixes this problem